### PR TITLE
Change the default prefix from ";" to "t!"

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,5 +1,5 @@
 {
-	"prefix": ";",
+	"prefix": "t!",
 	"logsChannel": "979473328622403674",
 	"moderationChannel": "988414226299228201",
 	"loaReports": "989611315893010502"


### PR DESCRIPTION
In the server, a lot of people use ";" by accident and causes Tinan to freak out. So (based on a suggestion from Ram#1337), I've change the default prefix to "t!".